### PR TITLE
Solved compiler messages

### DIFF
--- a/Source/AggConvCurve.pas
+++ b/Source/AggConvCurve.pas
@@ -4,7 +4,7 @@ unit AggConvCurve;
 //                                                                            //
 //  Anti-Grain Geometry (modernized Pascal fork, aka 'AggPasMod')             //
 //    Maintained by Christian-W. Budde (Christian@savioursofsoul.de)          //
-//    Copyright (c) 2012-2015                                                      //
+//    Copyright (c) 2012-2015                                                 //
 //                                                                            //
 //  Based on:                                                                 //
 //    Pascal port by Milan Marusinec alias Milano (milan@marusinec.sk)        //
@@ -79,6 +79,8 @@ type
     constructor Create(Source: TAggVertexSource; C3: TAggCurve3 = nil;
       C4: TAggCurve4 = nil);
     destructor Destroy; override;
+
+    procedure Reset; override;
 
     procedure Rewind(PathID: Cardinal); override;
     function Vertex(X, Y: PDouble): Cardinal; override;
@@ -166,6 +168,11 @@ end;
 function TAggConvCurve.GetCuspLimit: Double;
 begin
   Result := FCurve4.CuspLimit;
+end;
+
+procedure TAggConvCurve.Reset;
+begin
+  inherited;
 end;
 
 procedure TAggConvCurve.Rewind(PathID: Cardinal);

--- a/Source/AggConvTransform.pas
+++ b/Source/AggConvTransform.pas
@@ -4,7 +4,7 @@ unit AggConvTransform;
 //                                                                            //
 //  Anti-Grain Geometry (modernized Pascal fork, aka 'AggPasMod')             //
 //    Maintained by Christian-W. Budde (Christian@savioursofsoul.de)          //
-//    Copyright (c) 2012-2015                                                      //
+//    Copyright (c) 2012-2015                                                 //
 //                                                                            //
 //  Based on:                                                                 //
 //    Pascal port by Milan Marusinec alias Milano (milan@marusinec.sk)        //
@@ -37,7 +37,7 @@ type
     FSource: TAggVertexSource;
     FTrans: TAggTransAffine;
   protected
-    function GetPathID(Index: Cardinal): Cardinal; override;
+    //function GetPathID(Index: Cardinal): Cardinal; override;
     function GetPathCount: Cardinal; override;
   public
     constructor Create(Source: TAggVertexSource; Tr: TAggTransAffine);
@@ -67,10 +67,10 @@ begin
   Result := FSource.PathCount;
 end;
 
-function TAggConvTransform.GetPathID(Index: Cardinal): Cardinal;
+{function TAggConvTransform.GetPathID(Index: Cardinal): Cardinal;
 begin
   Result := FSource.PathID[Index];
-end;
+end;}
 
 procedure TAggConvTransform.Rewind(PathID: Cardinal);
 begin

--- a/Source/AggCurves.pas
+++ b/Source/AggCurves.pas
@@ -4,7 +4,7 @@ unit AggCurves;
 //                                                                            //
 //  Anti-Grain Geometry (modernized Pascal fork, aka 'AggPasMod')             //
 //    Maintained by Christian-W. Budde (Christian@savioursofsoul.de)          //
-//    Copyright (c) 2012-2015                                                      //
+//    Copyright (c) 2012-2015                                                 //
 //                                                                            //
 //  Based on:                                                                 //
 //    Pascal port by Milan Marusinec alias Milano (milan@marusinec.sk)        //

--- a/Source/AggEllipse.pas
+++ b/Source/AggEllipse.pas
@@ -4,7 +4,7 @@ unit AggEllipse;
 //                                                                            //
 //  Anti-Grain Geometry (modernized Pascal fork, aka 'AggPasMod')             //
 //    Maintained by Christian-W. Budde (Christian@savioursofsoul.de)          //
-//    Copyright (c) 2012-2015                                                      //
+//    Copyright (c) 2012-2015                                                 //
 //                                                                            //
 //  Based on:                                                                 //
 //    Pascal port by Milan Marusinec alias Milano (milan@marusinec.sk)        //
@@ -43,7 +43,7 @@ type
     procedure SetApproximationScale(Value: Double);
   protected
     procedure CalculateNumSteps; virtual; abstract;
-    function GetPathID(Index: Cardinal): Cardinal; override;
+    //function GetPathID(Index: Cardinal): Cardinal; override;
   public
     constructor Create; virtual;
 
@@ -104,10 +104,10 @@ begin
   FApproximationScale := 1.0;
 end;
 
-function TAggCustomEllipse.GetPathID(Index: Cardinal): Cardinal;
+{function TAggCustomEllipse.GetPathID(Index: Cardinal): Cardinal;
 begin
   Result := 0;
-end;
+end;}
 
 procedure TAggCustomEllipse.Rewind(PathID: Cardinal);
 begin

--- a/Source/AggFontFreetype.pas
+++ b/Source/AggFontFreetype.pas
@@ -1431,14 +1431,13 @@ end;
 
 procedure TAggFontEngineFreetypeBase.UpdateSignature;
 var
-  NameLength, GammaHash, I: Cardinal;
+  GammaHash, I: Cardinal;
   GammaTable: array [0..CAggAntiAliasingNum - 1] of Int8u;
   MatrixData: TAggParallelogram;
   Str: string;
 begin
   if (FCurFace <> nil) and (Length(FFaceName) <> 0) then
   begin
-    NameLength := Length(FFaceName);
 
     GammaHash := 0;
 

--- a/Source/AggFontWin32TrueType.pas
+++ b/Source/AggFontWin32TrueType.pas
@@ -4,7 +4,7 @@ unit AggFontWin32TrueType;
 //                                                                            //
 //  Anti-Grain Geometry (modernized Pascal fork, aka 'AggPasMod')             //
 //    Maintained by Christian-W. Budde (Christian@savioursofsoul.de)          //
-//    Copyright (c) 2012-2015                                                      //
+//    Copyright (c) 2012-2015                                                 //
 //                                                                            //
 //  Based on:                                                                 //
 //    Pascal port by Milan Marusinec alias Milano (milan@marusinec.sk)        //

--- a/Source/AggRasterizerScanLine.pas
+++ b/Source/AggRasterizerScanLine.pas
@@ -4,7 +4,7 @@ unit AggRasterizerScanLine;
 //                                                                            //
 //  Anti-Grain Geometry (modernized Pascal fork, aka 'AggPasMod')             //
 //    Maintained by Christian-W. Budde (Christian@savioursofsoul.de)          //
-//    Copyright (c) 2012-2015                                                      //
+//    Copyright (c) 2012-2015                                                 //
 //                                                                            //
 //  Based on:                                                                 //
 //    Pascal port by Milan Marusinec alias Milano (milan@marusinec.sk)        //
@@ -73,8 +73,9 @@ type
   TAggRasterizerScanline = class(TAggCustomBoundsRasterizerScanLine)
   public
     procedure Gamma(AGammaFunction: TAggCustomVertexSource); virtual; abstract;
-    function SweepScanLine(Sl: TAggCustomScanLine): Boolean; virtual; abstract;
-    function SweepScanLineEm(Sl: TAggCustomScanLine): Boolean; virtual; abstract;
+    function SweepScanLine(Sl: TAggCustomScanLine): Boolean; overload; virtual; abstract;
+    //function SweepScanLineEm(Sl: TAggCustomScanLine): Boolean; virtual; abstract;
+    function SweepScanLine(Sl: TAggEmbeddedScanLine): Boolean; overload; virtual; abstract;
   end;
 
 implementation

--- a/Source/AggRenderScanlines.pas
+++ b/Source/AggRenderScanlines.pas
@@ -46,16 +46,24 @@ implementation
 
 procedure RenderScanLines(Ras: TAggRasterizerScanLine; Sl: TAggCustomScanLine;
   Ren: TAggCustomRendererScanLine);
+var
+  SlEm: TAggEmbeddedScanline;
 begin
   if Ras.RewindScanLines then
   begin
     Sl.Reset(Ras.MinimumX, Ras.MaximumX);
     Ren.Prepare(Cardinal(Ras.MaximumX - Ras.MinimumX + 2));
 
-    if Sl.IsEmbedded then
+    {if Sl.IsEmbedded then
       while Ras.SweepScanLineEm(Sl) do
         Ren.Render(Sl)
-    else
+    else}
+    if Sl is TAggEmbeddedScanline then
+    begin
+      SlEm := Sl as TAggEmbeddedScanline;
+      while Ras.SweepScanLine(SlEm) do
+        Ren.Render(SlEm)
+    end else
       while Ras.SweepScanLine(Sl) do
         Ren.Render(Sl);
   end;

--- a/Source/AggRendererRasterText.pas
+++ b/Source/AggRendererRasterText.pas
@@ -4,7 +4,7 @@ unit AggRendererRasterText;
 //                                                                            //
 //  Anti-Grain Geometry (modernized Pascal fork, aka 'AggPasMod')             //
 //    Maintained by Christian-W. Budde (Christian@savioursofsoul.de)          //
-//    Copyright (c) 2012-2015                                                      //
+//    Copyright (c) 2012-2015                                                 //
 //                                                                            //
 //  Based on:                                                                 //
 //    Pascal port by Milan Marusinec alias Milano (milan@marusinec.sk)        //
@@ -74,16 +74,29 @@ type
 
   TAggScanLineSingleSpan = class(TAggCustomScanLine)
   private
+    type
+      TConstIterator = class(TAggCustomSpan)
+      private
+        FSpan: PAggConstSpan;
+      protected
+        function GetX: Integer; override;
+        function GetLength: Integer; override;
+        function Covers: PInt8u; override;
+      public
+        constructor Create(aScanline: TAggScanLineSingleSpan);
+        procedure IncOperator; override;
+      end;
+  private
     FY: Integer;
     FSpan: TAggConstSpan;
   protected
     function GetY: Integer; override;
     function GetNumSpans: Cardinal; override;
-    function GetSizeOfSpan: Cardinal; override;
+    //function GetSizeOfSpan: Cardinal; override;
   public
     constructor Create(X, Y: Integer; Len: Cardinal; Covers: PInt8u);
 
-    function GetBegin: Pointer; override;
+    function GetBegin: TAggCustomSpan; override;
   end;
 
   TAggRendererRasterHorizontalText = class
@@ -170,7 +183,6 @@ begin
   end;
 end;
 
-
 { TAggRendererRasterVerticalTextSolid }
 
 constructor TAggRendererRasterVerticalTextSolid.Create(Ren: TAggRendererBase; Glyph: TAggGlyphRasterBin);
@@ -232,7 +244,6 @@ begin
   end;
 end;
 
-
 { TAggConstSpan }
 
 procedure TAggConstSpan.Initialize(X: Integer; Len: Cardinal; Covers: PInt8u);
@@ -242,6 +253,34 @@ begin
   Self.Covers := Covers;
 end;
 
+{ TAggScanLineSingleSpan.TConstIterator }
+
+function TAggScanLineSingleSpan.TConstIterator.Covers: PInt8u;
+begin
+  Result := FSpan.Covers;
+end;
+
+constructor TAggScanLineSingleSpan.TConstIterator.Create(
+  aScanline: TAggScanLineSingleSpan);
+begin
+  inherited Create;
+  FSpan := @aScanline.FSpan;
+end;
+
+function TAggScanLineSingleSpan.TConstIterator.GetLength: Integer;
+begin
+  Result := FSpan.Len;
+end;
+
+function TAggScanLineSingleSpan.TConstIterator.GetX: Integer;
+begin
+  Result := FSpan.X;
+end;
+
+procedure TAggScanLineSingleSpan.TConstIterator.IncOperator;
+begin
+  inherited;
+end;
 
 { TAggScanLineSingleSpan }
 
@@ -263,16 +302,16 @@ begin
   Result := 1;
 end;
 
-function TAggScanLineSingleSpan.GetBegin: Pointer;
+function TAggScanLineSingleSpan.GetBegin: TAggCustomSpan;
 begin
-  Result := @FSpan;
+  //Result := @FSpan;
+  Result := TConstIterator.Create(Self);
 end;
 
-function TAggScanLineSingleSpan.GetSizeOfSpan: Cardinal;
+{function TAggScanLineSingleSpan.GetSizeOfSpan: Cardinal;
 begin
   Result := SizeOf(TAggConstSpan);
-end;
-
+end;}
 
 { TAggRendererRasterHorizontalText }
 

--- a/Source/AggRendererScanLine.pas
+++ b/Source/AggRendererScanLine.pas
@@ -4,7 +4,7 @@ unit AggRendererScanLine;
 //                                                                            //
 //  Anti-Grain Geometry (modernized Pascal fork, aka 'AggPasMod')             //
 //    Maintained by Christian-W. Budde (Christian@savioursofsoul.de)          //
-//    Copyright (c) 2012-2015                                                      //
+//    Copyright (c) 2012-2015                                                 //
 //                                                                            //
 //  Based on:                                                                 //
 //    Pascal port by Milan Marusinec alias Milano (milan@marusinec.sk)        //
@@ -41,7 +41,7 @@ uses
   AggRasterizerCompoundAA;
 
 type
-  TAggCustomRendererScanLine = class(TAggRasterizerScanLine)
+  TAggCustomRendererScanLine = class// class(TAggRasterizerScanLine)
   public
     procedure Prepare(U: Cardinal); virtual; abstract;
     procedure Render(Sl: TAggCustomScanLine); virtual; abstract;
@@ -153,10 +153,12 @@ procedure TAggRendererScanLineAA.Render(Sl: TAggCustomScanLine);
 var
   Y, Xmin, Xmax, X, Len: Integer;
 
-  NumSpans, Ss: Cardinal;
+  NumSpans: Cardinal;
+  //SS: Cardinal;
 
-  Span  : PAggSpanRecord;
-  Solid : Boolean;
+  //Span  : PAggSpanRecord;
+  Span: TAggCustomSpan;
+  Solid: Boolean;
   Covers: PInt8u;
 begin
   Y := Sl.Y;
@@ -172,7 +174,7 @@ begin
       NumSpans := Sl.NumSpans;
 
       Span := Sl.GetBegin;
-      Ss := Sl.SizeOfSpan;
+      //Ss := Sl.SizeOfSpan;
 
       repeat
         X := Span.X;
@@ -216,13 +218,15 @@ begin
         if NumSpans = 0 then
           Break;
 
-        Inc(PtrComp(Span), Ss);
+        //Inc(PtrComp(Span), Ss);
+        Span.IncOperator;
       until False;
+
+      Span.Free;
     end;
 
   until not FRen.NextClipBox;
 end;
-
 
 { TAggRendererScanLineAASolid }
 
@@ -250,28 +254,28 @@ end;
 procedure TAggRendererScanLineAASolid.Render(Sl: TAggCustomScanLine);
 var
   X, Y: Integer;
-
-  NumSpans, Ss: Cardinal;
-
-  SpanRecord : PAggSpanRecord;
+  //Ss: Cardinal;
+  //SpanRecord : PAggSpanRecord;
+  NumSpans: Cardinal;
   Span: TAggCustomSpan;
 begin
   Y := Sl.Y;
 
   NumSpans := Sl.NumSpans;
 
-  SpanRecord := nil;
-  Span := nil;
+  //SpanRecord := nil;
+  //Span := nil;
 
-  if Sl.IsPlainSpan then
-  begin
-    SpanRecord := Sl.GetBegin;
-    Ss := Sl.SizeOfSpan;
-  end
-  else
-    Span := Sl.GetBegin;
+  //if Sl.IsPlainSpan then
+  //begin
+  //  SpanRecord := Sl.GetBegin;
+  //  Ss := Sl.SizeOfSpan;
+  //end
+  //else
+  //  Span := Sl.GetBegin;
+  Span := Sl.GetBegin;
 
-  if SpanRecord <> nil then
+  {if SpanRecord <> nil then
     repeat
       X := SpanRecord.X;
 
@@ -290,7 +294,7 @@ begin
       Inc(PtrComp(SpanRecord), Ss);
     until False
   else
-    begin
+    begin}
       repeat
         X := Span.X;
 
@@ -309,10 +313,9 @@ begin
         Span.IncOperator;
       until False;
 
-      Span.Free;
-    end;
+  Span.Free;
+    {end;}
 end;
-
 
 { TAggRendererScanLineBinSolid }
 
@@ -338,13 +341,14 @@ end;
 
 procedure TAggRendererScanLineBinSolid.Render(Sl: TAggCustomScanLine);
 var
-  SpanPl : PAggSpanRecord;
+  //SpanPl: PAggSpanRecord;
+  //Ss: Cardinal;
   Span: TAggCustomSpan;
-  NumSpans, Ss: Cardinal;
+  NumSpans: Cardinal;
 begin
   NumSpans := Sl.NumSpans;
 
-  SpanPl := nil;
+  {SpanPl := nil;
   Span := nil;
 
   if Sl.IsPlainSpan then
@@ -353,9 +357,10 @@ begin
     Ss := Sl.SizeOfSpan;
   end
   else
-    Span := Sl.GetBegin;
+    Span := Sl.GetBegin;}
+  Span := Sl.GetBegin;
 
-  if SpanPl <> nil then
+  {if SpanPl <> nil then
     repeat
       if SpanPl.Len < 0 then
         FRen.BlendHorizontalLine(SpanPl.X, Sl.Y, SpanPl.X - 1 - SpanPl.Len,
@@ -371,7 +376,7 @@ begin
 
       Inc(PtrComp(SpanPl), Ss);
     until False
-  else
+  else}
     repeat
       if Span.Len < 0 then
         FRen.BlendHorizontalLine(Span.X, Sl.Y, Span.X - 1 - Span.Len,
@@ -387,22 +392,25 @@ begin
 
       Span.IncOperator;
     until False;
-end;
 
+  Span.Free;
+end;
 
 procedure RenderScanLineAASolid(Sl: TAggCustomScanLine; Ren: TAggRendererBase;
   Color: PAggColor);
 var
   Y, X: Integer;
-  NumSpans, Ss: Cardinal;
-  Span: PAggSpanRecord;
+  NumSpans: Cardinal;
+  //Ss: Cardinal;
+  //Span: PAggSpanRecord;
+  Span: TAggCustomSpan;
 begin
   Assert(Ren is TAggRendererBase);
 
   Y := Sl.Y;
   NumSpans := Sl.NumSpans;
   Span := Sl.GetBegin;
-  Ss := Sl.SizeOfSpan;
+  //Ss := Sl.SizeOfSpan;
 
   repeat
     X := Span.X;
@@ -417,16 +425,21 @@ begin
     if NumSpans = 0 then
       Break;
 
-    Inc(PtrComp(Span), Ss);
+    //Inc(PtrComp(Span), Ss);
+    Span.IncOperator;
   until False;
+
+  Span.Free;
 end;
 
 procedure RenderScanLinesAASolid(Ras: TAggRasterizerScanLine;
   Sl: TAggCustomScanLine; Ren: TAggRendererBase; Color: PAggColor);
 var
   Y, X: Integer;
-  NumSpans, Ss: Cardinal;
-  Span: PAggSpanRecord;
+  NumSpans: Cardinal;
+  //Ss: Cardinal;
+  //Span: PAggSpanRecord;
+  Span: TAggCustomSpan;
 begin
   Assert(Ren is TAggRendererBase);
 
@@ -438,7 +451,7 @@ begin
     begin
       Y := Sl.Y;
       NumSpans := Sl.NumSpans;
-      Ss := Sl.SizeOfSpan;
+      //Ss := Sl.SizeOfSpan;
       Span := Sl.GetBegin;
 
       repeat
@@ -455,8 +468,11 @@ begin
         if NumSpans = 0 then
           Break;
 
-        Inc(PtrComp(Span), Ss);
+        //Inc(PtrComp(Span), Ss);
+        Span.IncOperator;
       until False;
+
+      Span.Free;
     end;
   end;
 end;
@@ -466,13 +482,16 @@ procedure RenderScanLinesCompound(Ras: TAggRasterizerCompoundAA;
   Alloc: TAggSpanAllocator; StyleHandler: TAggCustomStyleHandler);
 var
   MinX, Len: Integer;
-  NumSpans, NumStyles, Style, I, SsAntiAlias, SsBin: Cardinal;
+  NumSpans, NumStyles, Style, I: Cardinal;
+  //SsAntiAlias, SsBin: Cardinal;
   ColorSpan, MixBuffer, Colors, ClrSpan: PAggColor;
   C: TAggColor;
   Solid: Boolean;
-  SpanAA : PAggSpanRecord;
-  SpanBin: PAggSpanBin;
-  Covers  : PInt8u;
+  //SpanAA: PAggSpanRecord;
+  //SpanBin: PAggSpanBin;
+  SpanAA: TAggCustomSpan;
+  SpanBin: TAggCustomSpan;
+  Covers: PInt8u;
 begin
   Assert(Ren is TAggRendererBase);
 
@@ -504,7 +523,7 @@ begin
           begin
             // Arbitrary Span generator
             SpanAA := ScanLineAA.GetBegin;
-            SsAntiAlias := ScanLineAA.SizeOfSpan;
+            //SsAntiAlias := ScanLineAA.SizeOfSpan;
             NumSpans := ScanLineAA.NumSpans;
 
             repeat
@@ -519,8 +538,11 @@ begin
               if NumSpans = 0 then
                 Break;
 
-              Inc(PtrComp(SpanAA), SsAntiAlias);
+              //Inc(PtrComp(SpanAA), SsAntiAlias);
+              SpanAA.IncOperator;
             until False;
+
+            SpanAA.Free;
           end;
         end
         else
@@ -529,7 +551,7 @@ begin
         begin
           // Clear the Spans of the MixBuffer
           SpanBin := SlBin.GetBegin;
-          SsBin := SlBin.SizeOfSpan;
+          //SsBin := SlBin.SizeOfSpan;
           NumSpans := SlBin.NumSpans;
 
           repeat
@@ -541,8 +563,11 @@ begin
             if NumSpans = 0 then
               Break;
 
-            Inc(PtrComp(SpanBin), SsBin);
+            //Inc(PtrComp(SpanBin), SsBin);
+            SpanBin.IncOperator;
           until False;
+
+          SpanBin.Free;
 
           I := 0;
 
@@ -554,7 +579,7 @@ begin
             if Ras.SweepScanLine(ScanLineAA, I) then
             begin
               SpanAA := ScanLineAA.GetBegin;
-              SsAntiAlias := ScanLineAA.SizeOfSpan;
+              //SsAntiAlias := ScanLineAA.SizeOfSpan;
               NumSpans := ScanLineAA.NumSpans;
 
               if Solid then
@@ -584,9 +609,11 @@ begin
                   if NumSpans = 0 then
                     Break;
 
-                  Inc(PtrComp(SpanAA), SsAntiAlias);
+                  //Inc(PtrComp(SpanAA), SsAntiAlias);
+                  SpanAA.IncOperator;
 
                 until False
+
               else
                 // Arbitrary Span generator
                 repeat
@@ -618,9 +645,12 @@ begin
                   if NumSpans = 0 then
                     Break;
 
-                  Inc(PtrComp(SpanAA), SsAntiAlias);
+                  //Inc(PtrComp(SpanAA), SsAntiAlias);
+                  SpanAA.IncOperator;
 
                 until False;
+
+              SpanAA.Free;
             end;
 
             Inc(I);
@@ -628,7 +658,7 @@ begin
 
           // Emit the blended result as a color hSpan
           SpanBin := SlBin.GetBegin;
-          SsBin := SlBin.SizeOfSpan;
+          //SsBin := SlBin.SizeOfSpan;
           NumSpans := SlBin.NumSpans;
 
           repeat
@@ -641,8 +671,11 @@ begin
             if NumSpans = 0 then
               Break;
 
-            Inc(PtrComp(SpanBin), SsBin);
+            //Inc(PtrComp(SpanBin), SsBin);
+            SpanBin.IncOperator;
           until False;
+
+          SpanBin.Free;
         end; // if ras.SweepScanLine(SlBin ,-1 )
 
       NumStyles := Ras.SweepStyles;
@@ -655,12 +688,14 @@ procedure RenderScanLinesCompoundLayered(Ras: TAggRasterizerCompoundAA;
   StyleHandler: TAggCustomStyleHandler);
 var
   MinX, Len, ScanLineStart, Sl_y: Integer;
-  NumSpans, NumStyles, Style, SsAntiAlias, ScanLineLen, I, Cover: Cardinal;
+  NumSpans, NumStyles, Style, ScanLineLen, I, Cover: Cardinal;
+  //SsAntiAlias: Cardinal;
   ColorSpan, MixBuffer, Colors, ClrSpan: PAggColor;
   Solid: Boolean;
   C: TAggColor;
   CoverBuffer, SourceCovers, DestCovers: PCover;
-  SpanAA: PAggSpanRecord;
+  //SpanAA: PAggSpanRecord;
+  SpanAA: TAggCustomSpan;
 begin
   Assert(Ren is TAggRendererBase);
 
@@ -694,7 +729,7 @@ begin
             // Arbitrary Span generator
             SpanAA := ScanLineAA.GetBegin;
             NumSpans := ScanLineAA.NumSpans;
-            SsAntiAlias := ScanLineAA.SizeOfSpan;
+            //SsAntiAlias := ScanLineAA.SizeOfSpan;
 
             repeat
               Len := SpanAA.Len;
@@ -708,9 +743,12 @@ begin
               if NumSpans = 0 then
                 Break;
 
-              Inc(PtrComp(SpanAA), SsAntiAlias);
+              //Inc(PtrComp(SpanAA), SsAntiAlias);
+              SpanAA.IncOperator;
 
             until False;
+
+            SpanAA.Free;
           end;
 
         end
@@ -742,7 +780,7 @@ begin
               SpanAA := ScanLineAA.GetBegin;
               NumSpans := ScanLineAA.NumSpans;
               Sl_y := ScanLineAA.Y;
-              SsAntiAlias := ScanLineAA.SizeOfSpan;
+              //SsAntiAlias := ScanLineAA.SizeOfSpan;
 
               if Solid then
                 // Just solid fill
@@ -783,7 +821,9 @@ begin
                   if NumSpans = 0 then
                     Break;
 
-                  Inc(PtrComp(SpanAA), SsAntiAlias);
+                  //Inc(PtrComp(SpanAA), SsAntiAlias);
+                  SpanAA.IncOperator;
+
                 until False
               else
                 // Arbitrary Span generator
@@ -826,9 +866,12 @@ begin
                   if NumSpans = 0 then
                     Break;
 
-                  Inc(PtrComp(SpanAA), SsAntiAlias);
+                  //Inc(PtrComp(SpanAA), SsAntiAlias);
+                  SpanAA.IncOperator;
 
                 until False;
+
+              SpanAA.Free;
             end;
 
             Inc(I);

--- a/Source/AggScanline.pas
+++ b/Source/AggScanline.pas
@@ -4,7 +4,7 @@ unit AggScanLine;
 //                                                                            //
 //  Anti-Grain Geometry (modernized Pascal fork, aka 'AggPasMod')             //
 //    Maintained by Christian-W. Budde (Christian@savioursofsoul.de)          //
-//    Copyright (c) 2012-2015                                                      //
+//    Copyright (c) 2012-2015                                                 //
 //                                                                            //
 //  Based on:                                                                 //
 //    Pascal port by Milan Marusinec alias Milano (milan@marusinec.sk)        //
@@ -51,9 +51,9 @@ type
 
   TAggCustomScanLine = class
   protected
-    function GetSizeOfSpan: Cardinal; virtual; abstract;
-    function GetIsPlainSpan: Boolean; virtual;
-    function GetIsEmbedded: Boolean; virtual;
+    //function GetSizeOfSpan: Cardinal; virtual; abstract;
+    //function GetIsPlainSpan: Boolean; virtual;
+    //function GetIsEmbedded: Boolean; virtual;
     function GetNumSpans: Cardinal; virtual; abstract;
     function GetY: Integer; virtual; abstract;
   public
@@ -66,20 +66,25 @@ type
       virtual; abstract;
     procedure AddSpan(X: Integer; Len, Cover: Cardinal); virtual; abstract;
 
-    function GetBegin: Pointer; virtual; abstract;
+    function GetBegin: TAggCustomSpan; virtual; abstract;
 
-    procedure Init(Ptr: PInt8u; Dx, Dy: Integer); virtual; abstract;
-    procedure Setup(ScanLineIndex: Cardinal); virtual; abstract;
+    //procedure Init(Ptr: PInt8u; Dx, Dy: Integer); virtual; abstract;
+    //procedure Setup(ScanLineIndex: Cardinal); virtual; abstract;
 
-    property IsPlainSpan: Boolean read GetIsPlainSpan;
-    property IsEmbedded: Boolean read GetIsEmbedded;
+    //property IsPlainSpan: Boolean read GetIsPlainSpan;
+    //property IsEmbedded: Boolean read GetIsEmbedded;
     property NumSpans: Cardinal read GetNumSpans;
-    property SizeOfSpan: Cardinal read GetSizeOfSpan;
+    //property SizeOfSpan: Cardinal read GetSizeOfSpan;
     property Y: Integer read GetY;
   end;
 
-implementation
+  TAggEmbeddedScanLine = class(TAggCustomScanline)
+  public
+    procedure Init(Ptr: PInt8u; Dx, Dy: Integer); virtual; abstract;
+    procedure Setup(ScanLineIndex: Cardinal); virtual; abstract;
+  end;
 
+implementation
 
 { TAggCustomSpan }
 
@@ -102,17 +107,16 @@ procedure TAggCustomSpan.IncOperator;
 begin
 end;
 
-
 { TAggCustomScanLine }
 
-function TAggCustomScanLine.GetIsPlainSpan: Boolean;
+{function TAggCustomScanLine.GetIsPlainSpan: Boolean;
 begin
   Result := True;
-end;
+end;}
 
-function TAggCustomScanLine.GetIsEmbedded: Boolean;
+{function TAggCustomScanLine.GetIsEmbedded: Boolean;
 begin
   Result := False;
-end;
+end;}
 
 end.

--- a/Source/AggScanlinePacked.pas
+++ b/Source/AggScanlinePacked.pas
@@ -4,7 +4,7 @@ unit AggScanLinePacked;
 //                                                                            //
 //  Anti-Grain Geometry (modernized Pascal fork, aka 'AggPasMod')             //
 //    Maintained by Christian-W. Budde (Christian@savioursofsoul.de)          //
-//    Copyright (c) 2012-2015                                                      //
+//    Copyright (c) 2012-2015                                                 //
 //                                                                            //
 //  Based on:                                                                 //
 //    Pascal port by Milan Marusinec alias Milano (milan@marusinec.sk)        //
@@ -40,6 +40,19 @@ type
 
   TAggScanLinePacked8 = class(TAggCustomScanLine)
   private
+    type
+      TConstIterator = class(TAggCustomSpan)
+      private
+        FSpan: PAggSpanPacked8;
+      protected
+        function GetX: Integer; override;
+        function GetLength: Integer; override;
+      public
+        constructor Create(aScanline: TAggScanLinePacked8);
+        function Covers: PInt8u; override;
+        procedure IncOperator; override;
+      end;
+  private
     FMaxLength: Cardinal;
     FLastX, FY: Integer;
     FCovers, FCoverPtr: PInt8u;
@@ -47,7 +60,7 @@ type
   protected
     function GetY: Integer; override;
     function GetNumSpans: Cardinal; override;
-    function GetSizeOfSpan: Cardinal; override;
+    //function GetSizeOfSpan: Cardinal; override;
   public
     constructor Create;
     destructor Destroy; override;
@@ -60,11 +73,41 @@ type
     procedure AddCells(X: Integer; Len: Cardinal; Covers: PInt8u); override;
     procedure AddSpan(X: Integer; Len, Cover: Cardinal); override;
 
-    function GetBegin: Pointer; override;
+    function GetBegin: TAggCustomSpan; override;
   end;
 
 implementation
 
+
+{ TAggScanLinePacked8.TConstIterator }
+
+function TAggScanLinePacked8.TConstIterator.Covers: PInt8u;
+begin
+  Result := FSpan.Covers;
+end;
+
+constructor TAggScanLinePacked8.TConstIterator.Create(
+  aScanline: TAggScanLinePacked8);
+begin
+  inherited Create;
+
+  FSpan := PAggSpanPacked8(PtrComp(aScanline.FSpans) + SizeOf(TAggSpanPacked8));
+end;
+
+function TAggScanLinePacked8.TConstIterator.GetLength: Integer;
+begin
+  Result := FSpan.Len;
+end;
+
+function TAggScanLinePacked8.TConstIterator.GetX: Integer;
+begin
+  Result := FSpan.X;
+end;
+
+procedure TAggScanLinePacked8.TConstIterator.IncOperator;
+begin
+  Inc(PtrComp(FSpan), SizeOf(TAggSpanPacked8));
+end;
 
 { TAggScanLinePacked8 }
 
@@ -202,14 +245,15 @@ begin
   Result := (PtrComp(FCurrentSpan) - PtrComp(FSpans)) div SizeOf(TAggSpanPacked8);
 end;
 
-function TAggScanLinePacked8.GetBegin: Pointer;
+function TAggScanLinePacked8.GetBegin: TAggCustomSpan;
 begin
-  Result := PAggSpanPacked8(PtrComp(FSpans) + SizeOf(TAggSpanPacked8));
+  //Result := PAggSpanPacked8(PtrComp(FSpans) + SizeOf(TAggSpanPacked8));
+  Result := TConstIterator.Create(Self);
 end;
 
-function TAggScanLinePacked8.GetSizeOfSpan: Cardinal;
+{function TAggScanLinePacked8.GetSizeOfSpan: Cardinal;
 begin
   Result := SizeOf(TAggSpanPacked8);
-end;
+end;}
 
 end.

--- a/Source/AggScanlineStorageAA.pas
+++ b/Source/AggScanlineStorageAA.pas
@@ -82,7 +82,7 @@ type
   end;
 
   TAggCustomScanLineStorageAA = class;
-  TAggEmbeddedScanLineSS = class;
+  {TAggEmbeddedScanLineSS = class;
 
   TAggConstIteratorSS = class(TAggCustomSpan)
   private
@@ -99,27 +99,44 @@ type
 
     procedure IncOperator; override;
     procedure IniTAggSpan;
-  end;
+  end;}
 
-  TAggEmbeddedScanLineSS = class(TAggCustomScanLine)
+  TAggEmbeddedScanLineSS = class(TAggEmbeddedScanLine)
+  private
+    type
+      TConstIterator = class(TAggCustomSpan)
+      private
+        FStorage: TAggCustomScanLineStorageAA;
+        FSpanIdx: Cardinal;
+        FSpan: TAggSpanSS;
+        procedure Init;
+      protected
+        function GetX: Integer; override;
+        function GetLength: Integer; override;
+      public
+        constructor Create(ScanLine: TAggEmbeddedScanLineSS);
+        function Covers: PInt8u; override;
+        procedure IncOperator; override;
+      end;
   private
     FStorage: TAggCustomScanLineStorageAA;
     FScanLine: TAggScanLineDataSS;
     FScanLineIndex: Cardinal;
 
-    FResult: TAggConstIteratorSS;
+    //FResult: TAggConstIteratorSS;
   public
     constructor Create(Storage: TAggCustomScanLineStorageAA);
+    destructor Destroy; override;
 
     procedure Reset(MinX, MaxX: Integer); override;
 
     function GetY: Integer; override;
     function GetNumSpans: Cardinal; override;
-    function GetBegin: Pointer; override;
+    function GetBegin: TAggCustomSpan; override;
 
-    function GetSizeOfSpan: Cardinal; override;
-    function GetIsPlainSpan: Boolean; override;
-    function GetIsEmbedded: Boolean; override;
+    //function GetSizeOfSpan: Cardinal; override;
+    //function GetIsPlainSpan: Boolean; override;
+    //function GetIsEmbedded: Boolean; override;
 
     procedure Setup(ScanLineIndex: Cardinal); override;
   end;
@@ -144,16 +161,17 @@ type
     procedure Render(Sl: TAggCustomScanLine); override;
 
     // Iterate ScanLines interface
-    function GetMinX: Integer; override;
-    function GetMinY: Integer; override;
-    function GetMaxX: Integer; override;
-    function GetMaxY: Integer; override;
+    function GetMinX: Integer; virtual;// override;
+    function GetMinY: Integer; virtual;// override;
+    function GetMaxX: Integer; virtual;// override;
+    function GetMaxY: Integer; virtual;// override;
 
-    function RewindScanLines: Boolean; override;
-    function SweepScanLine(Sl: TAggCustomScanLine): Boolean; override;
+    function RewindScanLines: Boolean; virtual;// override;
+    function SweepScanLine(Sl: TAggCustomScanLine): Boolean; overload; virtual;// override;
 
     // Specialization for embedded_ScanLine
-    function SweepScanLineEm(Sl: TAggCustomScanLine): Boolean; override;
+    //function SweepScanLineEm(Sl: TAggCustomScanLine): Boolean; virtual;// override;
+    function SweepScanLine(Sl: TAggEmbeddedScanLine): Boolean; overload; virtual;// override;
 
     function ByteSize: Cardinal; virtual;
     procedure WriteInt32(Dst: PInt8u; Val: Int32);
@@ -162,6 +180,11 @@ type
     function ScanLineByIndex(I: Cardinal): PAggScanLineDataSS;
     function SpanByIndex(I: Cardinal): PAggSpanDataSS;
     function CoversByIndex(I: Integer): Pointer;
+  public
+    property MinimumX: Integer read GetMinX;
+    property MinimumY: Integer read GetMinY;
+    property MaximumX: Integer read GetMaxX;
+    property MaximumY: Integer read GetMaxY;
   end;
 
   TAggScanLineStorageAA8 = class(TAggCustomScanLineStorageAA)
@@ -189,7 +212,7 @@ type
     procedure Serialize(Data: PInt8u); override;
   end;
 
-  TAggEmbeddedScanLineSA = class;
+  {TAggEmbeddedScanLineSA = class;
 
   TAggConstIteratorSA = class(TAggCustomSpan)
   private
@@ -213,9 +236,32 @@ type
     function ReadInt32: Integer;
 
     property Size: Cardinal read GetSize;
-  end;
+  end;}
 
-  TAggEmbeddedScanLineSA = class(TAggCustomScanLine)
+  //TAggEmbeddedScanLineSA = class(TAggCustomScanLine)
+  TAggEmbeddedScanLineSA = class(TAggEmbeddedScanLine)
+  private
+    type
+      TConstIterator = class(TAggCustomSpan)
+      private
+        FPtr: PInt8u;
+        FSpan: TAggSpanSS;
+
+        FDeltaX: Integer;
+        FSize: Cardinal;
+        function GetSize: Cardinal;
+        procedure Init;
+      protected
+        function GetX: Integer; override;
+        function GetLength: Integer; override;
+        function ReadInt32: Integer;
+      public
+        constructor Create(aScanLine: TAggEmbeddedScanLineSA; aSize: Cardinal);
+        function Covers: PInt8u; override;
+        procedure IncOperator; override;
+
+        property Size: Cardinal read GetSize;
+      end;
   private
     FPtr: PInt8u;
     FY: Integer;
@@ -225,22 +271,22 @@ type
     FDeltaX: Integer;
     FSize: Cardinal;
 
-    FResult: TAggConstIteratorSA;
-
+    //FResult: TAggConstIteratorSA;
     function GetSize: Cardinal;
   protected
     function GetY: Integer; override;
     function GetNumSpans: Cardinal; override;
 
-    function GetSizeOfSpan: Cardinal; override;
-    function GetIsPlainSpan: Boolean; override;
-    function GetIsEmbedded: Boolean; override;
+    //function GetSizeOfSpan: Cardinal; override;
+    //function GetIsPlainSpan: Boolean; override;
+    //function GetIsEmbedded: Boolean; override;
   public
     constructor Create(Size: Cardinal);
+    destructor Destroy; override;
 
     procedure Reset(MinX, MaxX: Integer); override;
 
-    function GetBegin: Pointer; override;
+    function GetBegin: TAggCustomSpan; override;
     procedure Init(Ptr: PInt8u; Dx, Dy: Integer); override;
 
     function ReadInt32: Integer;
@@ -278,7 +324,8 @@ type
     function SweepScanLine(Sl: TAggCustomScanLine): Boolean; override;
 
     // Specialization for embedded_ScanLine
-    function SweepScanLineEm(Sl: TAggCustomScanLine): Boolean; override;
+    //function SweepScanLineEm(Sl: TAggCustomScanLine): Boolean; override;
+    function SweepScanLine(Sl: TAggEmbeddedScanLine): Boolean; override;
 
     property Size: Cardinal read GetSize;
   end;
@@ -305,7 +352,6 @@ type
   end;
 
 implementation
-
 
 { TAggScanLineCellStorage }
 
@@ -453,10 +499,9 @@ begin
   end;
 end;
 
-
 { TAggConstIteratorSS }
 
-constructor TAggConstIteratorSS.Create;
+{constructor TAggConstIteratorSS.Create;
 begin
   FStorage := Sl.FStorage;
   FSpanIdx := Sl.FScanLine.StartSpan;
@@ -496,8 +541,50 @@ begin
   FSpan.X := S.X;
   FSpan.Len := S.Len;
   FSpan.Covers := FStorage.CoversByIndex(S.CoversID);
+end;}
+
+{ TAggEmbeddedScanLineSS.TConstIterator }
+
+function TAggEmbeddedScanLineSS.TConstIterator.Covers: PInt8u;
+begin
+  Result := FSpan.Covers;
 end;
 
+constructor TAggEmbeddedScanLineSS.TConstIterator.Create;
+begin
+  inherited Create;
+
+  FStorage := Scanline.FStorage;
+  FSpanIdx := Scanline.FScanLine.StartSpan;
+  Init;
+end;
+
+function TAggEmbeddedScanLineSS.TConstIterator.GetLength: Integer;
+begin
+  Result := FSpan.Len;
+end;
+
+function TAggEmbeddedScanLineSS.TConstIterator.GetX: Integer;
+begin
+  Result := FSpan.X;
+end;
+
+procedure TAggEmbeddedScanLineSS.TConstIterator.IncOperator;
+begin
+  Inc(FSpanIdx);
+  Init;
+end;
+
+procedure TAggEmbeddedScanLineSS.TConstIterator.Init;
+var
+  S: PAggSpanDataSS;
+begin
+  S := FStorage.SpanByIndex(FSpanIdx);
+
+  FSpan.X := S.X;
+  FSpan.Len := S.Len;
+  FSpan.Covers := FStorage.CoversByIndex(S.CoversID);
+end;
 
 { TAggEmbeddedScanLineSS }
 
@@ -522,37 +609,38 @@ begin
   Result := FScanLine.NumSpans;
 end;
 
-
-{ TAggEmbeddedScanLineSS }
+destructor TAggEmbeddedScanLineSS.Destroy;
+begin
+  inherited;
+end;
 
 function TAggEmbeddedScanLineSS.GetBegin;
 begin
-  FResult := TAggConstIteratorSS.Create(Self);
-
-  Result := FResult;
+  //FResult := TAggConstIteratorSS.Create(Self);
+  //Result := FResult;
+  Result := TConstIterator.Create(Self);
 end;
 
-function TAggEmbeddedScanLineSS.GetSizeOfSpan;
+{function TAggEmbeddedScanLineSS.GetSizeOfSpan;
 begin
   Result := SizeOf(TAggSpanSS);
-end;
+end;}
 
-function TAggEmbeddedScanLineSS.GetIsPlainSpan;
+{function TAggEmbeddedScanLineSS.GetIsPlainSpan;
 begin
   Result := False;
-end;
+end;}
 
-function TAggEmbeddedScanLineSS.GetIsEmbedded;
+{function TAggEmbeddedScanLineSS.GetIsEmbedded;
 begin
   Result := True;
-end;
+end;}
 
 procedure TAggEmbeddedScanLineSS.Setup;
 begin
   FScanLineIndex := ScanLineIndex;
   FScanLine := FStorage.ScanLineByIndex(FScanLineIndex)^;
 end;
-
 
 { TAggCustomScanLineStorageAA }
 
@@ -605,13 +693,12 @@ var
 
   Y, X1, X2, Len: Integer;
 
-  NumSpans, Ss: Cardinal;
-
-  SpanData : PAggSpanRecord;
+  NumSpans: Cardinal;
+  //Ss: Cardinal;
+  //SpanData : PAggSpanRecord;
   Span: TAggCustomSpan;
 
   Sp: TAggSpanDataSS;
-
 begin
   Y := Sl.Y;
 
@@ -627,7 +714,7 @@ begin
 
   NumSpans := ScanLineData.NumSpans;
 
-  SpanData := nil;
+  {SpanData := nil;
   Span := nil;
 
   if Sl.IsPlainSpan then
@@ -637,10 +724,11 @@ begin
     Ss := Sl.SizeOfSpan;
   end
   else
-    Span := Sl.GetBegin;
+    Span := Sl.GetBegin;}
+  Span := Sl.GetBegin;
 
   repeat
-    if SpanData <> nil then
+    {if SpanData <> nil then
     begin
       Sp.X := SpanData.X;
       Sp.Len := SpanData.Len;
@@ -649,14 +737,17 @@ begin
     begin
       Sp.X := Span.X;
       Sp.Len := Span.Len;
-    end;
+    end;}
+    Sp.X := Span.X;
+    Sp.Len := Span.Len;
 
     Len := Abs(Sp.Len);
 
-    if SpanData <> nil then
+    {if SpanData <> nil then
       Sp.CoversID := FCovers.AddCells(SpanData.Covers, Cardinal(Len))
     else
-      Sp.CoversID := FCovers.AddCells(Span.Covers, Cardinal(Len));
+      Sp.CoversID := FCovers.AddCells(Span.Covers, Cardinal(Len));}
+    Sp.CoversID := FCovers.AddCells(Span.Covers, Cardinal(Len));
 
     FSpans.Add(@Sp);
 
@@ -674,11 +765,14 @@ begin
     if NumSpans = 0 then
       Break;
 
-    if SpanData <> nil then
+    {if SpanData <> nil then
       Inc(PtrComp(SpanData), Ss)
     else
-      Span.IncOperator;
+      Span.IncOperator;}
+    Span.IncOperator;
   until False;
+
+  Span.Free;
 
   FScanLines.Add(@ScanLineData);
 end;
@@ -710,7 +804,8 @@ begin
   Result := FScanLines.Size > 0;
 end;
 
-function TAggCustomScanLineStorageAA.SweepScanLine;
+function TAggCustomScanLineStorageAA.SweepScanLine(
+  Sl: TAggCustomScanLine): Boolean;
 var
   ScanLineData: PAggScanLineDataSS;
   NumSpans, SpanIndex: Cardinal;
@@ -761,7 +856,9 @@ begin
   Result := True;
 end;
 
-function TAggCustomScanLineStorageAA.SweepScanLineEm;
+//function TAggCustomScanLineStorageAA.SweepScanLineEm;
+function TAggCustomScanLineStorageAA.SweepScanLine(
+  Sl: TAggEmbeddedScanLine): Boolean;
 begin
   repeat
     if FCurrentScanLine >= FScanLines.Size then
@@ -928,7 +1025,6 @@ begin
   Result := FCovers[I];
 end;
 
-
 { TAggScanLineStorageAA8 }
 
 constructor TAggScanLineStorageAA8.Create;
@@ -936,7 +1032,6 @@ begin
   inherited;
   FCovers := TAggScanLineCellStorage.Create(SizeOf(Int8u));
 end;
-
 
 { TAggScanLineStorageAA16 }
 
@@ -1111,7 +1206,6 @@ begin
   end;
 end;
 
-
 { TAggScanLineStorageAA32 }
 
 constructor TAggScanLineStorageAA32.Create;
@@ -1120,7 +1214,7 @@ begin
   FCovers := TAggScanLineCellStorage.Create(SizeOf(Int32u));
 end;
 
-function TAggScanLineStorageAA32.SweepScanLine;
+function TAggScanLineStorageAA32.SweepScanLine(Sl: TAggCustomScanLine): Boolean;
 var
   ScanLineThis: PAggScanLineDataSS;
 
@@ -1293,10 +1387,9 @@ begin
   end;
 end;
 
-
 { TAggConstIteratorSA }
 
-constructor TAggConstIteratorSA.Create(Sl: TAggEmbeddedScanLineSA; Sz: Cardinal);
+{constructor TAggConstIteratorSA.Create(Sl: TAggEmbeddedScanLineSA; Sz: Cardinal);
 begin
   FPtr := Sl.FPtr;
   FDeltaX := Sl.FDeltaX;
@@ -1352,8 +1445,69 @@ begin
   Inc(PtrComp(FPtr), SizeOf(Int8u));
   TInt32Int8uAccess(Result).Values[3] := FPtr^;
   Inc(PtrComp(FPtr), SizeOf(Int8u));
+end;}
+
+{ TAggEmbeddedScanLineSA.TConstIterator }
+
+function TAggEmbeddedScanLineSA.TConstIterator.Covers: PInt8u;
+begin
+  Result := FSpan.Covers;
 end;
 
+constructor TAggEmbeddedScanLineSA.TConstIterator.Create(
+  aScanLine: TAggEmbeddedScanLineSA; aSize: Cardinal);
+begin
+  inherited Create;
+  FPtr := aScanline.FPtr;
+  FDeltaX := aScanline.FDeltaX;
+  FSize := aSize;
+
+  Init;
+end;
+
+function TAggEmbeddedScanLineSA.TConstIterator.GetLength: Integer;
+begin
+  Result := FSpan.Len;
+end;
+
+function TAggEmbeddedScanLineSA.TConstIterator.GetSize: Cardinal;
+begin
+  Result := FSize;
+end;
+
+function TAggEmbeddedScanLineSA.TConstIterator.GetX: Integer;
+begin
+  Result := FSpan.X;
+end;
+
+procedure TAggEmbeddedScanLineSA.TConstIterator.IncOperator;
+begin
+  if FSpan.Len < 0 then
+    Inc(PtrComp(FPtr), FSize)
+  else
+    Inc(PtrComp(FPtr), FSpan.Len * FSize);
+
+  Init;
+end;
+
+procedure TAggEmbeddedScanLineSA.TConstIterator.Init;
+begin
+  FSpan.X := ReadInt32 + FDeltaX;
+  FSpan.Len := ReadInt32;
+  FSpan.Covers := FPtr;
+end;
+
+function TAggEmbeddedScanLineSA.TConstIterator.ReadInt32: Integer;
+begin
+  TInt32Int8uAccess(Result).Values[0] := FPtr^;
+  Inc(PtrComp(FPtr), SizeOf(Int8u));
+  TInt32Int8uAccess(Result).Values[1] := FPtr^;
+  Inc(PtrComp(FPtr), SizeOf(Int8u));
+  TInt32Int8uAccess(Result).Values[2] := FPtr^;
+  Inc(PtrComp(FPtr), SizeOf(Int8u));
+  TInt32Int8uAccess(Result).Values[3] := FPtr^;
+  Inc(PtrComp(FPtr), SizeOf(Int8u));
+end;
 
 { TAggEmbeddedScanLineSA }
 
@@ -1385,27 +1539,32 @@ begin
   Result := FNumSpans;
 end;
 
-function TAggEmbeddedScanLineSA.GetBegin: Pointer;
+destructor TAggEmbeddedScanLineSA.Destroy;
 begin
-  FResult := TAggConstIteratorSA.Create(Self, FSize);
-
-  Result := FResult;
+  inherited;
 end;
 
-function TAggEmbeddedScanLineSA.GetSizeOfSpan: Cardinal;
+function TAggEmbeddedScanLineSA.GetBegin: TAggCustomSpan;
+begin
+  //FResult := TAggConstIteratorSA.Create(Self, FSize);
+  //Result := FResult;
+  Result := TConstIterator.Create(Self, FSize);
+end;
+
+{function TAggEmbeddedScanLineSA.GetSizeOfSpan: Cardinal;
 begin
   Result := SizeOf(TAggSpanSS);
-end;
+end;}
 
-function TAggEmbeddedScanLineSA.GetIsPlainSpan: Boolean;
+{function TAggEmbeddedScanLineSA.GetIsPlainSpan: Boolean;
 begin
   Result := False;
-end;
+end;}
 
-function TAggEmbeddedScanLineSA.GetIsEmbedded: Boolean;
+{function TAggEmbeddedScanLineSA.GetIsEmbedded: Boolean;
 begin
   Result := True;
-end;
+end;}
 
 procedure TAggEmbeddedScanLineSA.Init(Ptr: PInt8u; Dx, Dy: Integer);
 begin
@@ -1426,7 +1585,6 @@ begin
   TInt32Int8uAccess(Result).Values[3] := FPtr^;
   Inc(PtrComp(FPtr), SizeOf(Int8u));
 end;
-
 
 { TAggSerializedScanLinesAdaptorAA }
 
@@ -1545,7 +1703,8 @@ begin
   Result := FMax.Y;
 end;
 
-function TAggSerializedScanLinesAdaptorAA.SweepScanLine(Sl: TAggCustomScanLine): Boolean;
+function TAggSerializedScanLinesAdaptorAA.SweepScanLine(
+  Sl: TAggCustomScanLine): Boolean;
 var
   Y, X, Len: Integer;
   NumSpans: Cardinal;
@@ -1589,7 +1748,9 @@ begin
   Result := True;
 end;
 
-function TAggSerializedScanLinesAdaptorAA.SweepScanLineEm;
+//function TAggSerializedScanLinesAdaptorAA.SweepScanLineEm;
+function TAggSerializedScanLinesAdaptorAA.SweepScanLine(
+  Sl: TAggEmbeddedScanLine): Boolean;
 var
   ByteSize: Cardinal;
 begin
@@ -1606,7 +1767,6 @@ begin
   Result := True;
 end;
 
-
 { TAggSerializedScanLinesAdaptorAA8 }
 
 constructor TAggSerializedScanLinesAdaptorAA8.Create;
@@ -1620,7 +1780,6 @@ begin
   inherited Create(SizeOf(Int8u), Data, ASize, Dx, Dy);
 end;
 
-
 { TAggSerializedScanLinesAdaptorAA16 }
 
 constructor TAggSerializedScanLinesAdaptorAA16.Create;
@@ -1633,7 +1792,6 @@ constructor TAggSerializedScanLinesAdaptorAA16.Create(Data: PInt8u;
 begin
   inherited Create(SizeOf(Int8u), Data, ASize, Dx, Dy);
 end;
-
 
 { TAggSerializedScanLinesAdaptorAA32 }
 

--- a/Source/AggScanlineStorageBin.pas
+++ b/Source/AggScanlineStorageBin.pas
@@ -4,7 +4,7 @@ unit AggScanLineStorageBin;
 //                                                                            //
 //  Anti-Grain Geometry (modernized Pascal fork, aka 'AggPasMod')             //
 //    Maintained by Christian-W. Budde (Christian@savioursofsoul.de)          //
-//    Copyright (c) 2012-2015                                                      //
+//    Copyright (c) 2012-2015                                                 //
 //                                                                            //
 //  Based on:                                                                 //
 //    Pascal port by Milan Marusinec alias Milano (milan@marusinec.sk)        //
@@ -49,7 +49,7 @@ type
   end;
 
   TAggScanLineStorageBin = class;
-  TAggEmbeddedScanLineBin = class;
+  {TAggEmbeddedScanLineBin = class;
 
   TAggConstIteratorBin = class(TAggCustomSpan)
   private
@@ -63,29 +63,44 @@ type
     function Len: Integer; virtual;
 
     procedure IncOperator; virtual;
-  end;
+  end;}
 
-  TAggEmbeddedScanLineBin = class(TAggCustomScanLine)
+  TAggEmbeddedScanLineBin = class(TAggEmbeddedScanLine)
+  private
+    type
+      TConstIterator = class(TAggCustomSpan)
+      private
+        FStorage: TAggScanLineStorageBin;
+        FSpanIndex: Cardinal;
+        FSpan: TAggSpanData;
+      protected
+        function GetX: Integer; override;
+        function GetLength: Integer; override;
+      public
+        constructor Create(ScanLine: TAggEmbeddedScanLineBin);
+        procedure IncOperator; override;
+      end;
   private
     FStorage: TAggScanLineStorageBin;
     FScanLine: TAggScanLineData;
 
     FScanLineIndex: Cardinal;
 
-    FResult: TAggConstIteratorBin;
+    //FResult: TAggConstIteratorBin;
   protected
     function GetY: Integer; override;
     function GetNumSpans: Cardinal; override;
 
-    function GetSizeOfSpan: Cardinal; override;
-    function GetIsPlainSpan: Boolean; override;
-    function GetIsEmbedded: Boolean; override;
+    //function GetSizeOfSpan: Cardinal; override;
+    //function GetIsPlainSpan: Boolean; override;
+    //function GetIsEmbedded: Boolean; override;
   public
     constructor Create(Storage: TAggScanLineStorageBin);
+    destructor Destroy; override;
 
     procedure Reset(MinX, MaxX: Integer); override;
 
-    function GetBegin: Pointer; override;
+    function GetBegin: TAggCustomSpan; override;
 
     procedure Setup(ScanLineIndex: Cardinal); override;
   end;
@@ -102,10 +117,10 @@ type
     FCurrentScanLine: Cardinal;
   protected
     // Iterate ScanLines interface
-    function GetMinX: Integer; override;
-    function GetMinY: Integer; override;
-    function GetMaxX: Integer; override;
-    function GetMaxY: Integer; override;
+    function GetMinX: Integer; virtual;// override;
+    function GetMinY: Integer; virtual;// override;
+    function GetMaxX: Integer; virtual;// override;
+    function GetMaxY: Integer; virtual;// override;
   public
     constructor Create;
     destructor Destroy; override;
@@ -114,11 +129,12 @@ type
     procedure Prepare(U: Cardinal); override;
     procedure Render(ScanLine: TAggCustomScanLine); override;
 
-    function RewindScanLines: Boolean; override;
-    function SweepScanLine(ScanLine: TAggCustomScanLine): Boolean; override;
+    function RewindScanLines: Boolean; virtual;// override;
+    function SweepScanLine(ScanLine: TAggCustomScanLine): Boolean; overload; virtual;// override;
 
     // Specialization for embedded_ScanLine
-    function SweepScanLineEm(ScanLine: TAggCustomScanLine): Boolean; override;
+    //function SweepScanLineEm(ScanLine: TAggCustomScanLine): Boolean; virtual;// override;
+    function SweepScanLine(ScanLine: TAggEmbeddedScanLine): Boolean; overload; virtual;// override;
 
     function ByteSize: Cardinal;
     procedure WriteInt32(Dst: PInt8u; Val: Int32);
@@ -126,9 +142,14 @@ type
 
     function ScanLineByIndex(I: Cardinal): PAggScanLineData;
     function SpanByIndex(I: Cardinal): PAggSpanData;
+  public
+    property MinimumX: Integer read GetMinX;
+    property MinimumY: Integer read GetMinY;
+    property MaximumX: Integer read GetMaxX;
+    property MaximumY: Integer read GetMaxY;
   end;
 
-  TAggEmbeddedScanLineA = class;
+  {TAggEmbeddedScanLineA = class;
 
   TAggConstIteratorA = class(TAggCustomSpan)
   private
@@ -144,9 +165,24 @@ type
     procedure IncOperator; virtual;
 
     function ReadInt32: Integer;
-  end;
+  end;}
 
-  TAggEmbeddedScanLineA = class(TAggCustomScanLine)
+  TAggEmbeddedScanLineA = class(TAggEmbeddedScanLine)
+  private
+    type
+      TConstIterator = class(TAggCustomSpan)
+      private
+        FInternalData: PInt8u;
+        FSpan: TAggSpanData;
+        FDeltaX: Integer;
+        function ReadInt32: Integer;
+      protected
+        function GetX: Integer; override;
+        function GetLength: Integer; override;
+      public
+        constructor Create(ScanLine: TAggEmbeddedScanLineA);
+        procedure IncOperator; override;
+      end;
   private
     FInternalData: PInt8u;
     FY: Integer;
@@ -155,20 +191,21 @@ type
 
     FDeltaX: Integer;
 
-    FResult: TAggConstIteratorA;
+    //FResult: TAggConstIteratorA;
   protected
     function GetY: Integer; override;
     function GetNumSpans: Cardinal; override;
 
-    function GetSizeOfSpan: Cardinal; override;
-    function GetIsPlainSpan: Boolean; override;
-    function GetIsEmbedded: Boolean; override;
+    //function GetSizeOfSpan: Cardinal; override;
+    //function GetIsPlainSpan: Boolean; override;
+    //function GetIsEmbedded: Boolean; override;
   public
     constructor Create;
+    destructor Destroy; override;
 
     procedure Reset(MinX, MaxX: Integer); override;
 
-    function GetBegin: Pointer; override;
+    function GetBegin: TAggCustomSpan; override;
 
     function ReadInt32: Integer;
     procedure Init(Ptr: PInt8u; Dx, Dy: Integer); override;
@@ -198,15 +235,15 @@ type
     function SweepScanLine(ScanLine: TAggCustomScanLine): Boolean; override;
 
     // Specialization for embedded_ScanLine
-    function SweepScanLineEm(ScanLine: TAggCustomScanLine): Boolean; override;
+    //function SweepScanLineEm(ScanLine: TAggCustomScanLine): Boolean; override;
+    function SweepScanLine(ScanLine: TAggEmbeddedScanLine): Boolean; override;
   end;
 
 implementation
 
-
 { TAggConstIteratorBin }
 
-constructor TAggConstIteratorBin.Create;
+{constructor TAggConstIteratorBin.Create(ScanLine: TAggEmbeddedScanLineBin);
 begin
   FStorage := ScanLine.FStorage;
   FSpanIndex := ScanLine.FScanLine.Start_Span;
@@ -229,8 +266,37 @@ begin
   Inc(FSpanIndex);
 
   FSpan := FStorage.SpanByIndex(FSpanIndex)^;
+end;}
+
+
+{ TAggEmbeddedScanLineBin.TConstIterator }
+
+constructor TAggEmbeddedScanLineBin.TConstIterator.Create(
+  ScanLine: TAggEmbeddedScanLineBin);
+begin
+  inherited Create;
+  FStorage := ScanLine.FStorage;
+  FSpanIndex := ScanLine.FScanLine.Start_Span;
+
+  FSpan := FStorage.SpanByIndex(FSpanIndex)^;
 end;
 
+function TAggEmbeddedScanLineBin.TConstIterator.GetLength: Integer;
+begin
+  Result := FSpan.Len;
+end;
+
+function TAggEmbeddedScanLineBin.TConstIterator.GetX: Integer;
+begin
+  Result := FSpan.X;
+end;
+
+procedure TAggEmbeddedScanLineBin.TConstIterator.IncOperator;
+begin
+  Inc(FSpanIndex);
+
+  FSpan := FStorage.SpanByIndex(FSpanIndex)^;
+end;
 
 { TAggEmbeddedScanLineBin }
 
@@ -255,34 +321,38 @@ begin
   Result := FScanLine.NumSpans;
 end;
 
+destructor TAggEmbeddedScanLineBin.Destroy;
+begin
+  inherited;
+end;
+
 function TAggEmbeddedScanLineBin.GetBegin;
 begin
-  FResult := TAggConstIteratorBin.Create(@Self);
-
-  Result := FResult;
+  //FResult := TAggConstIteratorBin.Create(@Self);
+  //Result := FResult;
+  Result := TConstIterator.Create(Self);
 end;
 
-function TAggEmbeddedScanLineBin.GetSizeOfSpan;
+{function TAggEmbeddedScanLineBin.GetSizeOfSpan;
 begin
   Result := SizeOf(TAggSpanData);
-end;
+end;}
 
-function TAggEmbeddedScanLineBin.GetIsPlainSpan;
+{function TAggEmbeddedScanLineBin.GetIsPlainSpan;
 begin
   Result := False;
-end;
+end;}
 
-function TAggEmbeddedScanLineBin.GetIsEmbedded;
+{function TAggEmbeddedScanLineBin.GetIsEmbedded;
 begin
   Result := True;
-end;
+end;}
 
 procedure TAggEmbeddedScanLineBin.Setup;
 begin
   FScanLineIndex := ScanLineIndex;
   FScanLine := FStorage.ScanLineByIndex(FScanLineIndex)^;
 end;
-
 
 { TAggScanLineStorageBin }
 
@@ -333,10 +403,9 @@ var
   ScanLineData  : TAggScanLineData;
   NumSpans: Cardinal;
 
-  SpanData : PAggSpanData;
+  //SpanData : PAggSpanData;
+  //Ss: Cardinal;
   Span: TAggCustomSpan;
-
-  Ss: Cardinal;
   Sp: TAggSpanData;
 begin
   Y := ScanLine.Y;
@@ -353,7 +422,7 @@ begin
 
   NumSpans := ScanLineData.NumSpans;
 
-  SpanData := nil;
+  {SpanData := nil;
   Span := nil;
 
   if ScanLine.IsPlainSpan then
@@ -363,10 +432,11 @@ begin
     Ss := ScanLine.SizeOfSpan;
   end
   else
-    Span := ScanLine.GetBegin;
+    Span := ScanLine.GetBegin;}
+  Span := ScanLine.GetBegin;
 
   repeat
-    if SpanData <> nil then
+    {if SpanData <> nil then
     begin
       Sp.X := SpanData.X;
       Sp.Len := SpanData.Len;
@@ -375,7 +445,9 @@ begin
     begin
       Sp.X := Span.X;
       Sp.Len := Span.Len;
-    end;
+    end;}
+    Sp.X := Span.X;
+    Sp.Len := Span.Len;
 
     FSpans.Add(@Sp);
 
@@ -393,11 +465,14 @@ begin
     if NumSpans = 0 then
       Break;
 
-    if SpanData <> nil then
+    {if SpanData <> nil then
       Inc(PtrComp(SpanData), Ss)
     else
-      Span.IncOperator;
+      Span.IncOperator;}
+    Span.IncOperator;
   until False;
+
+  Span.Free;
 
   FScanLines.Add(@ScanLineData);
 end;
@@ -475,8 +550,9 @@ begin
   Result := True;
 end;
 
-function TAggScanLineStorageBin.SweepScanLineEm(
-  ScanLine: TAggCustomScanLine): Boolean;
+//function TAggScanLineStorageBin.SweepScanLineEm(ScanLine: TAggCustomScanLine): Boolean;
+function TAggScanLineStorageBin.SweepScanLine(
+  ScanLine: TAggEmbeddedScanLine): Boolean;
 begin
   repeat
     if FCurrentScanLine >= FScanLines.Size then
@@ -591,10 +667,9 @@ begin
     Result := @FFakeSpan;
 end;
 
-
 { TAggConstIteratorA }
 
-constructor TAggConstIteratorA.Create;
+{constructor TAggConstIteratorA.Create(ScanLine: TAggEmbeddedScanLineA);
 begin
   FInternalData := ScanLine.FInternalData;
   FDeltaX := ScanLine.FDeltaX;
@@ -629,8 +704,48 @@ begin
   Inc(PtrComp(FInternalData), SizeOf(Int8u));
   TInt32Int8uAccess(Result).Values[3] := FInternalData^;
   Inc(PtrComp(FInternalData), SizeOf(Int8u));
+end;}
+
+{ TAggEmbeddedScanLineA.TConstIterator }
+
+constructor TAggEmbeddedScanLineA.TConstIterator.Create(
+  ScanLine: TAggEmbeddedScanLineA);
+begin
+  inherited Create;
+  FInternalData := ScanLine.FInternalData;
+  FDeltaX := ScanLine.FDeltaX;
+
+  FSpan.X := ReadInt32 + FDeltaX;
+  FSpan.Len := ReadInt32;
 end;
 
+function TAggEmbeddedScanLineA.TConstIterator.GetLength: Integer;
+begin
+  Result := FSpan.Len;
+end;
+
+function TAggEmbeddedScanLineA.TConstIterator.GetX: Integer;
+begin
+  Result := FSpan.X;
+end;
+
+procedure TAggEmbeddedScanLineA.TConstIterator.IncOperator;
+begin
+  FSpan.X := ReadInt32 + FDeltaX;
+  FSpan.Len := ReadInt32;
+end;
+
+function TAggEmbeddedScanLineA.TConstIterator.ReadInt32: Integer;
+begin
+  TInt32Int8uAccess(Result).Values[0] := FInternalData^;
+  Inc(PtrComp(FInternalData), SizeOf(Int8u));
+  TInt32Int8uAccess(Result).Values[1] := FInternalData^;
+  Inc(PtrComp(FInternalData), SizeOf(Int8u));
+  TInt32Int8uAccess(Result).Values[2] := FInternalData^;
+  Inc(PtrComp(FInternalData), SizeOf(Int8u));
+  TInt32Int8uAccess(Result).Values[3] := FInternalData^;
+  Inc(PtrComp(FInternalData), SizeOf(Int8u));
+end;
 
 { TAggEmbeddedScanLineA }
 
@@ -656,27 +771,32 @@ begin
   Result := FNumSpans;
 end;
 
+destructor TAggEmbeddedScanLineA.Destroy;
+begin
+  inherited;
+end;
+
 function TAggEmbeddedScanLineA.GetBegin;
 begin
-  FResult := TAggConstIteratorA.Create(Self);
-
-  Result := FResult;
+  //FResult := TAggConstIteratorA.Create(Self);
+  //Result := FResult;
+  Result := TConstIterator.Create(Self);
 end;
 
-function TAggEmbeddedScanLineA.GetSizeOfSpan: Cardinal;
+{function TAggEmbeddedScanLineA.GetSizeOfSpan: Cardinal;
 begin
   Result := SizeOf(TAggSpanData);
-end;
+end;}
 
-function TAggEmbeddedScanLineA.GetIsPlainSpan: Boolean;
+{function TAggEmbeddedScanLineA.GetIsPlainSpan: Boolean;
 begin
   Result := False;
-end;
+end;}
 
-function TAggEmbeddedScanLineA.GetIsEmbedded: Boolean;
+{function TAggEmbeddedScanLineA.GetIsEmbedded: Boolean;
 begin
   Result := True;
-end;
+end;}
 
 function TAggEmbeddedScanLineA.ReadInt32: Integer;
 begin
@@ -697,7 +817,6 @@ begin
   FNumSpans := Cardinal(ReadInt32);
   FDeltaX := Dx;
 end;
-
 
 { TAggSerializedScanLinesAdaptorBin }
 
@@ -750,6 +869,8 @@ end;
 
 function TAggSerializedScanLinesAdaptorBin.ReadInt32: Integer;
 begin
+  Result := 0;
+
   TInt32Int8uAccess(Result).Values[0] := FInternalData^;
   Inc(PtrComp(FInternalData), SizeOf(Int8u));
   TInt32Int8uAccess(Result).Values[1] := FInternalData^;
@@ -840,7 +961,9 @@ begin
   Result := True;
 end;
 
-function TAggSerializedScanLinesAdaptorBin.SweepScanLineEm(ScanLine: TAggCustomScanLine): Boolean;
+//function TAggSerializedScanLinesAdaptorBin.SweepScanLineEm(ScanLine: TAggCustomScanLine): Boolean;
+function TAggSerializedScanLinesAdaptorBin.SweepScanLine(
+  ScanLine: TAggEmbeddedScanLine): Boolean;
 var
   NumSpans: Integer;
 begin

--- a/Source/AggTransAffine.pas
+++ b/Source/AggTransAffine.pas
@@ -4,7 +4,7 @@ unit AggTransAffine;
 //                                                                            //
 //  Anti-Grain Geometry (modernized Pascal fork, aka 'AggPasMod')             //
 //    Maintained by Christian-W. Budde (Christian@savioursofsoul.de)          //
-//    Copyright (c) 2012-2015                                                      //
+//    Copyright (c) 2012-2015                                                 //
 //                                                                            //
 //  Based on:                                                                 //
 //    Pascal port by Milan Marusinec alias Milano (milan@marusinec.sk)        //
@@ -589,8 +589,6 @@ begin
 end;
 
 procedure TAggTransAffine.PreMultiply(M: TAggTransAffine);
-var
-  T: TAggTransAffine;
 begin
   Transform := @M.Transform;
   Transform2x2 := @M.Transform2x2;

--- a/Source/AggVertexSource.pas
+++ b/Source/AggVertexSource.pas
@@ -4,7 +4,7 @@ unit AggVertexSource;
 //                                                                            //
 //  Anti-Grain Geometry (modernized Pascal fork, aka 'AggPasMod')             //
 //    Maintained by Christian-W. Budde (Christian@savioursofsoul.de)          //
-//    Copyright (c) 2012-2015                                                      //
+//    Copyright (c) 2012-2015                                                 //
 //                                                                            //
 //  Based on:                                                                 //
 //    Pascal port by Milan Marusinec alias Milano (milan@marusinec.sk)        //
@@ -47,12 +47,12 @@ type
 
   TAggVertexSource = class(TAggCustomVertexSource)
   protected
-    function GetPathID(Index: Cardinal): Cardinal; virtual; abstract;
+    //function GetPathID(Index: Cardinal): Cardinal; virtual; abstract;
   public
     procedure RemoveAll; virtual;
     procedure AddVertex(X, Y: Double; Cmd: Cardinal); virtual;
 
-    property PathID[Index: Cardinal]: Cardinal read GetPathID;
+    //property PathID[Index: Cardinal]: Cardinal read GetPathID;
   end;
 
 implementation

--- a/Source/FireMonkey/FMX.Canvas.AggPas.pas
+++ b/Source/FireMonkey/FMX.Canvas.AggPas.pas
@@ -2677,6 +2677,7 @@ var
   Curves: TAggConvCurve;
   Contour: TAggConvContour;
   ContourTransform: TAggConvTransform;
+  RenBin: TAggRendererScanLineBinSolid;
 begin
   X := aTextRect.Left;
   Y := aTextRect.Top - aAscend;
@@ -2693,6 +2694,7 @@ begin
 
   Curves.ApproximationScale := 2;
   Contour.AutoDetectOrientation := False;
+  RenBin := TAggRendererScanLineBinSolid.Create(FRendererBase);
   try
     i := 0;
     while i < Length(aText) do
@@ -2706,20 +2708,23 @@ begin
         aFontCacheManager.AddKerning(@X, @Y);
        {$ENDIF}
 
-        aFontCacheManager.InitEmbeddedAdaptors(Glyph, X, Y);
-
         case Glyph.DataType of
-          {TODO:
           gdMono:
             begin
+              aFontCacheManager.InitEmbeddedAdaptors(Glyph,
+                FTransform.M4 + X, FTransform.M5 + Y);
+
               RenBin.SetColor(CRgba8Black);
 
               RenderScanLines(aFontCacheManager.MonoAdaptor,
                 aFontCacheManager.MonoScanLine, RenBin);
-            end;}
+            end;
 
           gdGray8:
             begin
+              aFontCacheManager.InitEmbeddedAdaptors(Glyph,
+                FTransform.M4 + X, FTransform.M5 + Y);
+
               FRendererSolid.SetColor(CRgba8Black);
 
               RenderScanLines(aFontCacheManager.Gray8Adaptor,
@@ -2728,6 +2733,8 @@ begin
 
           gdOutline:
             begin
+              aFontCacheManager.InitEmbeddedAdaptors(Glyph, X, Y);
+
               FRasterizer.Reset;
 
               {if Abs(FSliderWeight.Value) <= 0.01 then
@@ -2751,6 +2758,7 @@ begin
       Inc(i);
     end;
   finally
+    RenBin.Free;
     ContourTransform.Free;
     Curves.Free;
     Contour.Free;
@@ -4711,7 +4719,7 @@ begin
     else
       B := 400;
 
-    FFontEngine.CreateFont(FontFamily, grOutline, FontSize, 0, B, Italic)
+    FFontEngine.CreateFont(FontFamily, {grNativeMono}grNativeGray8{grOutline}, FontSize, 0, B, Italic)
   end;
   {$ENDIF}
 end;

--- a/Source/FireMonkey/Test/XE5/Project1.dpr
+++ b/Source/FireMonkey/Test/XE5/Project1.dpr
@@ -70,7 +70,10 @@ uses
   AggBitsetIterator in '..\..\..\AggBitsetIterator.pas',
   AggConvContour in '..\..\..\AggConvContour.pas',
   AggVcgenContour in '..\..\..\AggVcgenContour.pas',
-  AggFontWin32TrueType in '..\..\..\AggFontWin32TrueType.pas';
+  AggFontWin32TrueType in '..\..\..\AggFontWin32TrueType.pas',
+  AggScanlineBooleanAlgebra in '..\..\..\AggScanlineBooleanAlgebra.pas',
+  AggRendererRasterText in '..\..\..\AggRendererRasterText.pas',
+  AggGlyphRasterBin in '..\..\..\AggGlyphRasterBin.pas';
 
 {$R *.res}
 

--- a/Source/FireMonkey/Test/XE5/Project1.dproj
+++ b/Source/FireMonkey/Test/XE5/Project1.dproj
@@ -165,6 +165,9 @@
         <DCCReference Include="..\..\..\AggConvContour.pas"/>
         <DCCReference Include="..\..\..\AggVcgenContour.pas"/>
         <DCCReference Include="..\..\..\AggFontWin32TrueType.pas"/>
+        <DCCReference Include="..\..\..\AggScanlineBooleanAlgebra.pas"/>
+        <DCCReference Include="..\..\..\AggRendererRasterText.pas"/>
+        <DCCReference Include="..\..\..\AggGlyphRasterBin.pas"/>
         <None Include="..\..\..\..\AggPasMod\Source\AggCompiler.inc"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>


### PR DESCRIPTION
and added nested interator class to scanline lasses, removed some unneeded class members.

- AggScanline.pas, AggRenderScanlin.pas, AggScanLinePacked, AggScanlineUnpacked, AggScanLineBin.pas, AggScanLineStorageAA, AggScanLineStorageBin, AggScanLineBooleanAlgebra.pas, AggRendererRasterText: Added a nested TConstIterator class to all TAggCustomScanline derived classes to have a uniform interface for iterating over spans. Reason is I found some cases where 16bit span records that where assigned to 32bit span records. The GetIsPLainSpan and GetSizeOfSpan members in the scanline classes are not needed anymore and I removed them.

- AggScanline.pas, AggScanLineStorageBin, AggScanLineStorageAA.pas, AggRenderScanLines, AggRasterizerScanLine: Added TAggEmbeddedScanLine as a base class for embedded scanlines. The GetIsEmbedded member is therefore not needed anymore and removed.
 
 - AggRenderScanlin.pas: Removed inheritance of TAggCustomRendererScanLine from TAggRasterizerScanLine to solve some compiler warnings about abstract members.
 
 - AggVertexSource.pas, AggConvTransform.pas, AggEllipse.pas: Removed GetPathID, because it generated compiler warnings about creation of class with abstract member and is not used
 
 - AggConvCurve.pas: Added stub for Reset member because it generated a compiler warning about creation of class with abstract member