### PR TITLE
Fixes compile error in FreePascal

### DIFF
--- a/Source/3rd Party/Expat/Expat.pas
+++ b/Source/3rd Party/Expat/Expat.pas
@@ -2477,7 +2477,7 @@ begin
     Parser.EventEndPtr := Next;
 
     case Tok of
-      TXmlTok(-Integer(xtProlog_S)):
+      xtBreak: 
         begin
           if @Parser.DefaultHandler <> nil then
           begin

--- a/Source/3rd Party/Expat/xmltok.pas
+++ b/Source/3rd Party/Expat/xmltok.pas
@@ -53,6 +53,8 @@ type
 
   PXmlTok = ^TXmlTok;
   TXmlTok = (
+  { The break token }
+    xtBreak = -15, 
   { The following token may be returned ByteType XmlContentTok }
     xtTrailingRSQB = -5, { ] or ]] at the end of the scan, might be
     start of illegal ]]> sequence }


### PR DESCRIPTION
I have compile error in **AggPasDesLaz** package: "Expat.pas(2480,36) Error: range check error while evaluating constants (-15 must be between -5 and 42)s".
`      TXmlTok(-Integer(xtProlog_S)): `
Indeed, **TXmlTok** has a range of -5 to 42, but _-Integer(xtProlog_S)_ cause -15.
I made a simple fix for this error.
Compilation is now successful, I hope everything is ok.